### PR TITLE
Fix phyloseq mara

### DIFF
--- a/tools/phyloseq/macros.xml
+++ b/tools/phyloseq/macros.xml
@@ -12,7 +12,6 @@
             <requirement type="package" version="@TOOL_VERSION@">bioconductor-phyloseq</requirement>
             <requirement type="package" version="1.7.3">r-optparse</requirement>
             <requirement type="package" version="2.0.0">r-tidyverse</requirement>
-            <requirement type="package" version="3.3.0">r-ggplot2</requirement>
         </requirements>
     </xml>
     <xml name="phyloseq_input">

--- a/tools/phyloseq/phyloseq_plot_bar.xml
+++ b/tools/phyloseq/phyloseq_plot_bar.xml
@@ -11,7 +11,8 @@ Rscript '${__tool_directory__}/phyloseq_plot_bar.R'
 --x '$x'
 --fill '$fill'
 --facet '${facet}'
---output '$output'
+--output 'tmp.pdf' &&
+cp 'tmp.pdf' '$output'
   ]]></command>
   <inputs>
     <expand macro="phyloseq_input"/>


### PR DESCRIPTION
Hi mara, 
two issues were:
* the new ggplot requirement was not compatible with the other packages, so all test failed, since the container could not be build, ggplot is not really needed as extra dependency since phyloseq has it already
* the ggplot save function needs a file with the correct output, so creating a tmp.pdf and then moving this to the *.dat file works